### PR TITLE
Corrects typo in health check route

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ However if the token is invalid or has expired `pam_hook` responds with:
 
 ### Healthcheck:
 
-Health check route is `/hearbeat`
+Health check route is `/heartbeat`
 
 
 ### Building:


### PR DESCRIPTION
I verified the URL in [main.go#L292](https://github.com/bjhaid/pam_hook/blob/07b41f8887e7a40317ef491b23850967afc8e2e8/main.go#L292).