### PR TITLE
Fix timestamps in token to conform to JWT spec

### DIFF
--- a/main.go
+++ b/main.go
@@ -175,10 +175,11 @@ func createToken(username string, c *Config, tokenExpiresIn int) (string,
 	claims := jws.Claims{
 		"username": username,
 	}
+	now := time.Now().UTC()
 	claims.SetAudience(*c.Audience)
-	claims.SetIssuedAt(time.Now())
+	claims.SetIssuedAt(now)
 	claims.SetIssuer(*c.ServerName)
-	claims.SetExpiration(time.Now().Add(time.Minute *
+	claims.SetExpiration(now.Add(time.Minute *
 		time.Duration(tokenExpiresIn)))
 
 	j := jws.NewJWT(claims, crypto.SigningMethodHS256)


### PR DESCRIPTION
pam_hook uses `time.Now()` which returns a [local time](https://golang.org/pkg/time/#Now).  The [JWT spec](https://tools.ietf.org/html/rfc7519#section-2) says that timestamps are to be seconds since epoch, which is relative to UTC.

This tiny fix ensures the timestamps in the `exp` and `iat` fields are conformant.